### PR TITLE
Information about my favorite movie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# App-Dev
-My first repository
+# My Favorite Series
+## The Wrong Turn 
+
+**1. Wrong Turn 1**
+
+**2. Wrong Turn 2**
+
+**3. Wrong Turn 3**
+
+**4. Wrong Turn 4**
+
+**5. Wrong Turn 5**
+
+**6. Wrong Turn 6**
+
+ Friends Jessie (Eliza Dushku) and Carly (Emmanuelle Chriqui) are traveling with pals Scott (Jeremy Sisto), Evan (Kevin Zegers) and Francine (Lindy Booth) when they have car trouble in West Virginia. Moments later, motorist Chris (Desmond Harrington) crashes into their disabled vehicle. Stranded, the friends discover that they're being stalked by a horde of backwoods cannibals. The woodsmen are hungry and fierce, and they'll be eating well unless Jessie and pals can outsmart them.
+   ---
+   [Wrong Turn 1] https://moviesanywhere.com/movie/wrong-turn
+
+   ! ![MV5BNDhkYmM1MWUtZDNiNy00NmI0LTg1NWQtYzk1Mzk1NmQzMmU2XkEyXkFqcGc@ _V1_QL75_UX140_CR0,1,140,207_](https://github.com/user-attachments/assets/4004bc8a-39cf-4d5d-bd91-c46b9edecda6)


### PR DESCRIPTION
Wrong Turn is an American slasher film series created by director Rob Schmidt and writers Alan B. McElroy, Adam Cooper and Bill Collage. The series consists of seven films, five of which share the same continuity, while the later two films serve as reboots.